### PR TITLE
Add Appveyor CI configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+os: Visual Studio 2015
+
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python --version"
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain nightly --default-host x86_64-pc-windows-msvc
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -V
+  - cargo -V
+  - cargo install pyo3-pack
+
+build_script:
+- pyo3-pack build
+
+artifacts:
+  - path: '**/*.whl'
+    name: Wheels


### PR DESCRIPTION
This adds CI builds for Windows. As an additional benefit it extracts artifacts, so we can also upload wheels to PyPI.

For now, I don't want to upload artifacts automatically. We could do that once we are happy with the automatic builds.