### PR TITLE
Return numpy arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ features = ["extension-module"]
 failure = "0.1"
 finalfusion = "0.5"
 libc = "0.2"
+numpy = "0.5"
 toml = "0.4"


### PR DESCRIPTION
This change makes `embedding` and the iterator return 1D numpy arrays rather than Python lists.

One small annoyance is that using the module actually requires numpy (as expected), however, I don't think there is a way to specify this dependency using pyo3-pack. So, a `pip install` of the wheel will not automatically fetch numpy as a dependency if it is not installed.

I guess we could investigate this more before doing an actual release and/or filing an issue with `pyo3-pack`.