### PR TITLE
Add a method to copy the entire matrix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ features = ["extension-module"]
 failure = "0.1"
 finalfusion = "0.5"
 libc = "0.2"
+ndarray = "0.12"
 numpy = "0.5"
 toml = "0.4"


### PR DESCRIPTION
Not sure if there's a way to handle the `QuantizedArray` case more gracefully.

Is this what you had in mind in #5?

I think the matrix by itself is pretty useless, so adding a method to get the vocab in the Python module would be up next. Or at least adding a way to get the length of the vocab, so it's possible to figure out the offset into the matrix where the subword embeddings start.