### PR TITLE
pyo3-pack from crates.io does not include Cargo.lock

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -V
   - cargo -V
-  - cargo install pyo3-pack --vers 0.6.1
+  - cargo install --git https://github.com/PyO3/pyo3-pack.git --tag v0.6.1 pyo3-pack
 
 build_script:
 - pyo3-pack build --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
       source venv/bin/activate
       pip install cffi virtualenv pytest numpy
     fi
-  - cargo install pyo3-pack --vers 0.6.1
+  - cargo install --git https://github.com/PyO3/pyo3-pack.git --tag v0.6.1 pyo3-pack
   - rustup default nightly-2019-02-07
   - rustup component add rustfmt
 


### PR DESCRIPTION
As a result, the ground is changing underneath us. Install pyo3-pack
from git instead to pin the versions to those in Cargo.lock.