### PR TITLE
Return None instead of raising exceptions for missing items.

### DIFF
--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -23,20 +23,16 @@ impl PyVocab {
 
 #[pymethods]
 impl PyVocab {
-    fn item_to_indices(&self, key: String) -> PyResult<PyObject> {
+    fn item_to_indices(&self, key: String) -> Option<PyObject> {
         let embeds = self.embeddings.borrow();
 
-        embeds
-            .vocab()
-            .idx(key.as_str())
-            .map(|idx| {
-                let gil = pyo3::Python::acquire_gil();
-                match idx {
-                    WordIndex::Word(idx) => [idx].to_object(gil.python()),
-                    WordIndex::Subword(indices) => indices.to_object(gil.python()),
-                }
-            })
-            .ok_or_else(|| exceptions::KeyError::py_err("Unknown word or n-grams"))
+        embeds.vocab().idx(key.as_str()).map(|idx| {
+            let gil = pyo3::Python::acquire_gil();
+            match idx {
+                WordIndex::Word(idx) => [idx].to_object(gil.python()),
+                WordIndex::Subword(indices) => indices.to_object(gil.python()),
+            }
+        })
     }
 }
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -31,6 +31,12 @@ def test_embeddings_with_norms():
             embedding_with_norm) == 3, "The number of values returned by 'iter_with_norm()' does not match!"
 
 
+def test_embeddings_with_norms_oov():
+    embeds = finalfusion.Embeddings(
+        "tests/embeddings.fifu")
+    assert embeds.embedding_with_norm("Something out of vocabulary") is None
+
+
 def test_embeddings():
     embeds = finalfusion.Embeddings(
         "tests/embeddings.fifu")
@@ -47,6 +53,12 @@ def test_embeddings():
             unnormed_embed, test_embed), "Embedding from normal iterator fails to match!"
         assert len(
             embedding_with_norm) == 2, "The number of values returned by normal iterator does not match!"
+
+
+def test_embeddings_oov():
+    embeds = finalfusion.Embeddings(
+        "tests/embeddings.fifu")
+    assert embeds.embedding("Something out of vocabulary") is None
 
 
 def test_norms():

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,0 +1,9 @@
+import finalfusion
+import pytest
+
+
+def test_embeddings_with_norms_oov():
+    embeds = finalfusion.Embeddings(
+        "tests/embeddings.fifu")
+    vocab = embeds.vocab()
+    assert vocab.item_to_indices("Something out of vocabulary") is None


### PR DESCRIPTION
Change some methods to return None rather than raising exceptions when an item is missing.

Addresses #32. I wasn't sure how to change the behaviour of the analogy and similarity methods. There it might even be justified to raise an exception.

I'm planning to do a followup PR to implement `PyMappingProtocol` for `Embeddings` to allow direct indexing through `embeddings["Query"]` in Python (which would then raise exceptions for missing inputs ;)).