### PR TITLE
Cleanup unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+
+import finalfusion
+import numpy
+import pytest
+
+
+@pytest.fixture
+def analogy_fifu(tests_root):
+    yield finalfusion.Embeddings(os.path.join(tests_root, "analogy.fifu"))
+
+
+@pytest.fixture
+def embeddings_fifu(tests_root):
+    yield finalfusion.Embeddings(os.path.join(tests_root, "embeddings.fifu"))
+
+
+@pytest.fixture
+def embeddings_text(tests_root):
+    embeds = dict()
+
+    with open(os.path.join(tests_root, "embeddings.txt"), "r", encoding="utf8") as lines:
+        for line in lines:
+            line_list = line.split(' ')
+            embeds[line_list[0]] = numpy.array(
+                [float(c) for c in line_list[1:]])
+
+    yield embeds
+
+
+@pytest.fixture
+def similarity_fifu(tests_root):
+    yield finalfusion.Embeddings(os.path.join(tests_root, "similarity.fifu"))
+
+
+@pytest.fixture
+def tests_root():
+    yield os.path.dirname(__file__)

--- a/tests/test_analogy.py
+++ b/tests/test_analogy.py
@@ -1,4 +1,4 @@
-import finalfusion
+import pytest
 
 ANALOGY_ORDER = [
     "Deutschland",
@@ -43,22 +43,48 @@ ANALOGY_ORDER = [
     "Westfalen",
 ]
 
-def test_analogies():
-    embeds = finalfusion.Embeddings('tests/analogy.fifu')
-    for idx, analogy in enumerate(embeds.analogy("Paris", "Frankreich", "Berlin", 40)):
+
+def test_analogies(analogy_fifu):
+    for idx, analogy in enumerate(
+            analogy_fifu.analogy(
+            "Paris", "Frankreich", "Berlin", 40)):
         assert ANALOGY_ORDER[idx] == analogy.word
 
-    assert embeds.analogy("Paris", "Frankreich", "Paris", 1, (True, False, True))[0].word == "Frankreich"
-    assert embeds.analogy("Paris", "Frankreich", "Paris", 1, (True, True, True))[0].word != "Frankreich"
-    assert embeds.analogy("Frankreich", "Frankreich", "Frankreich", 1, (False, False, False))[0].word == "Frankreich"
-    assert embeds.analogy("Frankreich", "Frankreich", "Frankreich", 1, (False, False, True))[0].word != "Frankreich"
-    try:
-        embeds.analogy("Paris", "Frankreich", "Paris", 1, (True, True))
-        assert True == False
-    except:
-        ()
-    try:
-        embeds.analogy("Paris", "Frankreich", "Paris", 1, (True, True, True, True))
-        assert True == False
-    except:
-        ()
+    assert analogy_fifu.analogy(
+        "Paris",
+        "Frankreich",
+        "Paris",
+        1,
+        (True,
+         False,
+         True))[0].word == "Frankreich"
+    assert analogy_fifu.analogy(
+        "Paris",
+        "Frankreich",
+        "Paris",
+        1,
+        (True,
+         True,
+         True))[0].word != "Frankreich"
+    assert analogy_fifu.analogy(
+        "Frankreich",
+        "Frankreich",
+        "Frankreich",
+        1,
+        (False,
+         False,
+         False))[0].word == "Frankreich"
+    assert analogy_fifu.analogy(
+        "Frankreich",
+        "Frankreich",
+        "Frankreich",
+        1,
+        (False,
+         False,
+         True))[0].word != "Frankreich"
+
+    with pytest.raises(ValueError):
+        analogy_fifu.analogy("Paris", "Frankreich", "Paris", 1, (True, True))
+    with pytest.raises(ValueError):
+        analogy_fifu.analogy("Paris", "Frankreich", "Paris",
+                             1, (True, True, True, True))

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,4 +1,3 @@
-import finalfusion
 import pytest
 import numpy
 
@@ -13,63 +12,38 @@ TEST_NORMS = [
 ]
 
 
-def test_embeddings_with_norms():
-    embeds = finalfusion.Embeddings(
-        "tests/embeddings.fifu")
-    embeds_dict = dict()
-    with open("tests/embeddings.txt", "r", encoding="utf8") as lines:
-        for line in lines:
-            line_list = line.split(' ')
-            embeds_dict[line_list[0]] = [float(val) for val in line_list[1:]]
-
-    for embedding_with_norm, norm in zip(embeds.iter_with_norm(), TEST_NORMS):
+def test_embeddings_with_norms(embeddings_fifu, embeddings_text):
+    for embedding_with_norm, norm in zip(
+            embeddings_fifu.iter_with_norm(), TEST_NORMS):
         unnormed_embed = embedding_with_norm[1] * norm
-        test_embed = embeds_dict[embedding_with_norm[0]]
+        test_embed = embeddings_text[embedding_with_norm[0]]
         assert numpy.allclose(
             unnormed_embed, test_embed), "Embedding from 'iter_with_norm()' fails to match!"
         assert len(
             embedding_with_norm) == 3, "The number of values returned by 'iter_with_norm()' does not match!"
 
 
-def test_embeddings_with_norms_oov():
-    embeds = finalfusion.Embeddings(
-        "tests/embeddings.fifu")
-    assert embeds.embedding_with_norm("Something out of vocabulary") is None
+def test_embeddings_with_norms_oov(embeddings_fifu):
+    assert embeddings_fifu.embedding_with_norm(
+        "Something out of vocabulary") is None
 
 
-def test_embeddings():
-    embeds = finalfusion.Embeddings(
-        "tests/embeddings.fifu")
-    embeds_dict = dict()
-    with open("tests/embeddings.txt", "r", encoding="utf8") as lines:
-        for line in lines:
-            line_list = line.split(' ')
-            embeds_dict[line_list[0]] = [float(i) for i in line_list[1:]]
-
-    for embedding_with_norm, norm in zip(embeds, TEST_NORMS):
+def test_embeddings(embeddings_fifu, embeddings_text):
+    for embedding_with_norm, norm in zip(embeddings_fifu, TEST_NORMS):
         unnormed_embed = embedding_with_norm[1] * norm
-        test_embed = embeds_dict[embedding_with_norm[0]]
+        test_embed = embeddings_text[embedding_with_norm[0]]
         assert numpy.allclose(
             unnormed_embed, test_embed), "Embedding from normal iterator fails to match!"
         assert len(
             embedding_with_norm) == 2, "The number of values returned by normal iterator does not match!"
 
 
-def test_embeddings_oov():
-    embeds = finalfusion.Embeddings(
-        "tests/embeddings.fifu")
-    assert embeds.embedding("Something out of vocabulary") is None
+def test_embeddings_oov(embeddings_fifu):
+    assert embeddings_fifu.embedding("Something out of vocabulary") is None
 
 
-def test_norms():
-    embeds = finalfusion.Embeddings(
-        "tests/embeddings.fifu")
-    embeds_dict = dict()
-    with open("tests/embeddings.txt", "r", encoding="utf8") as lines:
-        for line in lines:
-            line_list = line.split(' ')
-            embeds_dict[line_list[0]] = [float(val) for val in line_list[1:]]
-
-    for embedding_with_norm, norm in zip(embeds.iter_with_norm(), TEST_NORMS):
+def test_norms(embeddings_fifu):
+    for embedding_with_norm, norm in zip(
+            embeddings_fifu.iter_with_norm(), TEST_NORMS):
         assert pytest.approx(
-            embedding_with_norm[2] == norm), "Norm fails to match!"
+            embedding_with_norm[2]) == norm, "Norm fails to match!"

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,68 +1,66 @@
-import finalfusion
-
 SIMILARITY_ORDER_STUTTGART_10 = [
-        "Karlsruhe",
-        "Mannheim",
-        "München",
-        "Darmstadt",
-        "Heidelberg",
-        "Wiesbaden",
-        "Kassel",
-        "Düsseldorf",
-        "Leipzig",
-        "Berlin",
-    ];
+    "Karlsruhe",
+    "Mannheim",
+    "München",
+    "Darmstadt",
+    "Heidelberg",
+    "Wiesbaden",
+    "Kassel",
+    "Düsseldorf",
+    "Leipzig",
+    "Berlin",
+]
 
 
 SIMILARITY_ORDER = [
-        "Potsdam",
-        "Hamburg",
-        "Leipzig",
-        "Dresden",
-        "München",
-        "Düsseldorf",
-        "Bonn",
-        "Stuttgart",
-        "Weimar",
-        "Berlin-Charlottenburg",
-        "Rostock",
-        "Karlsruhe",
-        "Chemnitz",
-        "Breslau",
-        "Wiesbaden",
-        "Hannover",
-        "Mannheim",
-        "Kassel",
-        "Köln",
-        "Danzig",
-        "Erfurt",
-        "Dessau",
-        "Bremen",
-        "Charlottenburg",
-        "Magdeburg",
-        "Neuruppin",
-        "Darmstadt",
-        "Jena",
-        "Wien",
-        "Heidelberg",
-        "Dortmund",
-        "Stettin",
-        "Schwerin",
-        "Neubrandenburg",
-        "Greifswald",
-        "Göttingen",
-        "Braunschweig",
-        "Berliner",
-        "Warschau",
-        "Berlin-Spandau",
-    ];
+    "Potsdam",
+    "Hamburg",
+    "Leipzig",
+    "Dresden",
+    "München",
+    "Düsseldorf",
+    "Bonn",
+    "Stuttgart",
+    "Weimar",
+    "Berlin-Charlottenburg",
+    "Rostock",
+    "Karlsruhe",
+    "Chemnitz",
+    "Breslau",
+    "Wiesbaden",
+    "Hannover",
+    "Mannheim",
+    "Kassel",
+    "Köln",
+    "Danzig",
+    "Erfurt",
+    "Dessau",
+    "Bremen",
+    "Charlottenburg",
+    "Magdeburg",
+    "Neuruppin",
+    "Darmstadt",
+    "Jena",
+    "Wien",
+    "Heidelberg",
+    "Dortmund",
+    "Stettin",
+    "Schwerin",
+    "Neubrandenburg",
+    "Greifswald",
+    "Göttingen",
+    "Braunschweig",
+    "Berliner",
+    "Warschau",
+    "Berlin-Spandau",
+]
 
-def test_similarity_berlin_40():
-    embeds = finalfusion.Embeddings('tests/similarity.fifu')
-    for idx, sim in enumerate(embeds.similarity("Berlin", 40)):
+
+def test_similarity_berlin_40(similarity_fifu):
+    for idx, sim in enumerate(similarity_fifu.similarity("Berlin", 40)):
         assert SIMILARITY_ORDER[idx] == sim.word
 
-def test_similarity_stuttgart_10():
-    embeds = finalfusion.Embeddings('tests/similarity.fifu')
-    for idx, sim in enumerate(embeds.similarity("Stuttgart", 10)):
+
+def test_similarity_stuttgart_10(similarity_fifu):
+    for idx, sim in enumerate(similarity_fifu.similarity("Stuttgart", 10)):
         assert SIMILARITY_ORDER_STUTTGART_10[idx] == sim.word

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,9 +1,3 @@
-import finalfusion
-import pytest
-
-
-def test_embeddings_with_norms_oov():
-    embeds = finalfusion.Embeddings(
-        "tests/embeddings.fifu")
-    vocab = embeds.vocab()
+def test_embeddings_with_norms_oov(embeddings_fifu):
+    vocab = embeddings_fifu.vocab()
     assert vocab.item_to_indices("Something out of vocabulary") is None


### PR DESCRIPTION
- Use fixtures to remove repeated code.
- Replace some incorrect try-except blocks by pytest.raises.
- Miscellaneous cleaning.