### PR TITLE
Integrate changes from finalfusion-rust.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,11 +144,10 @@ dependencies = [
 
 [[package]]
 name = "finalfusion"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://github.com/finalfusion/finalfusion-rust.git?rev=8e360c6#8e360c60de7cd1b750528a329c691922b57eadef"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,7 +164,8 @@ name = "finalfusion-python"
 version = "0.4.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finalfusion 0.7.0 (git+https://github.com/finalfusion/finalfusion-rust.git?rev=8e360c6)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "numpy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -709,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-"checksum finalfusion 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "040f6b1d829f76dd459bb5ebb91943a4de06954432eb8aced3b58604b48c3a05"
+"checksum finalfusion 0.7.0 (git+https://github.com/finalfusion/finalfusion-rust.git?rev=8e360c6)" = "<none>"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ version = "0.7"
 features = ["extension-module"]
 
 [dependencies]
+itertools = "0.8"
 failure = "0.1"
-finalfusion = "0.7"
+finalfusion = { git = "https://github.com/finalfusion/finalfusion-rust.git", rev = "8e360c6" }
 libc = "0.2"
 ndarray = "0.12"
 numpy = "0.6"

--- a/tests/test_analogy.py
+++ b/tests/test_analogy.py
@@ -88,3 +88,5 @@ def test_analogies(analogy_fifu):
     with pytest.raises(ValueError):
         analogy_fifu.analogy("Paris", "Frankreich", "Paris",
                              1, (True, True, True, True))
+    with pytest.raises(KeyError):
+        analogy_fifu.analogy("Paris", "OOV", "Paris", 1, (True, True, True))


### PR DESCRIPTION
Temporarily changes the finalfusion-rust dependency to the github
repo. Report missing words in failed analogy queries, rename the
similarity method to word_similarity.

_______

Also adds a dependency to itertools.

Next up would be adding a `embedding_similarity` method.