### PR TITLE
Add convenience method to get viewable embeddings.

### DIFF
--- a/src/embeddings_wrap.rs
+++ b/src/embeddings_wrap.rs
@@ -39,4 +39,11 @@ impl EmbeddingsWrap {
             NonView(e) => e.embedding(word),
         }
     }
+
+    pub fn view(&self) -> Option<&Embeddings<VocabWrap, StorageViewWrap>> {
+        match self {
+            EmbeddingsWrap::NonView(_) => None,
+            EmbeddingsWrap::View(storage) => Some(storage),
+        }
+    }
 }


### PR DESCRIPTION
Thought this could be nice to have since writing the `embedding_similarity` method would entail repeating that match for the third time. Getting an option allows us to use `ok_or_else` and propagating the error through `?`.