### PR TITLE
Add embedding similarity queries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "finalfusion"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,7 +165,7 @@ name = "finalfusion-python"
 version = "0.4.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finalfusion 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -723,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-"checksum finalfusion 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c0ef4682a4505fd7b28b94f7f5f4cddcd2e8938a15ba91eb1e75315c6b156ed"
+"checksum finalfusion 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e9f3fea8f0007b57cbad8dbb0b27f0ac0402b7aaa8546cf18a30d930bbc7cf"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::rc::Rc;
@@ -12,11 +13,11 @@ use finalfusion::prelude::*;
 use finalfusion::similarity::*;
 use itertools::Itertools;
 use ndarray::Array2;
-use numpy::{IntoPyArray, PyArray1, PyArray2};
+use numpy::{IntoPyArray, NpyDataType, PyArray1, PyArray2};
 use pyo3::class::iter::PyIterProtocol;
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
-use pyo3::{exceptions, PyMappingProtocol};
+use pyo3::types::{PyAny, PyList, PySet, PyTuple};
+use pyo3::{exceptions, PyMappingProtocol, PyTypeInfo};
 use toml::{self, Value};
 
 use crate::{EmbeddingsWrap, PyEmbeddingIterator, PyVocab, PyWordSimilarity};
@@ -143,18 +144,7 @@ impl PyEmbeddings {
                 exceptions::KeyError::py_err(format!("Unknown word or n-grams: {}", failed))
             })?;
 
-        let mut r = Vec::with_capacity(results.len());
-        for ws in results {
-            r.push(
-                Py::new(
-                    py,
-                    PyWordSimilarity::new(ws.word.to_owned(), ws.similarity.into_inner()),
-                )?
-                .into_object(py),
-            )
-        }
-
-        Ok(r)
+        Self::similarity_results(py, results)
     }
 
     /// Get the embedding for the given word.
@@ -258,7 +248,7 @@ impl PyEmbeddings {
 
     /// Perform a similarity query.
     #[args(limit = 10)]
-    fn similarity(&self, py: Python, word: &str, limit: usize) -> PyResult<Vec<PyObject>> {
+    fn word_similarity(&self, py: Python, word: &str, limit: usize) -> PyResult<Vec<PyObject>> {
         let embeddings = self.embeddings.borrow();
 
         let embeddings = embeddings.view().ok_or_else(|| {
@@ -271,18 +261,46 @@ impl PyEmbeddings {
             .word_similarity(word, limit)
             .ok_or_else(|| exceptions::KeyError::py_err("Unknown word and n-grams"))?;
 
-        let mut r = Vec::with_capacity(results.len());
-        for ws in results {
-            r.push(
-                Py::new(
-                    py,
-                    PyWordSimilarity::new(ws.word.to_owned(), ws.similarity.into_inner()),
-                )?
-                .into_object(py),
+        Self::similarity_results(py, results)
+    }
+
+    /// Perform a similarity query based on a query embedding.
+    #[args(limit = 10, skip = "None")]
+    fn embedding_similarity(
+        &self,
+        py: Python,
+        embedding: PyEmbedding,
+        skip: Option<Option<Skips>>,
+        limit: usize,
+    ) -> PyResult<Vec<PyObject>> {
+        let embeddings = self.embeddings.borrow();
+
+        let embeddings = embeddings.view().ok_or_else(|| {
+            exceptions::ValueError::py_err(
+                "Similarity queries are not supported for this type of embedding matrix",
             )
+        })?;
+
+        let embedding = embedding.0.as_array();
+
+        if embedding.shape()[0] != embeddings.storage().shape().1 {
+            return Err(exceptions::ValueError::py_err(format!(
+                "Incompatible embedding shapes: embeddings: ({},), query: ({},)",
+                embedding.shape()[0],
+                embeddings.storage().shape().1
+            )));
         }
 
-        Ok(r)
+        let results = if let Some(Some(skip)) = skip {
+            embeddings.embedding_similarity_masked(embedding, limit, &skip.0)
+        } else {
+            embeddings.embedding_similarity(embedding, limit)
+        };
+
+        Self::similarity_results(
+            py,
+            results.ok_or_else(|| exceptions::KeyError::py_err("Unknown word and n-grams"))?,
+        )
     }
 
     /// Write the embeddings to a finalfusion file.
@@ -301,6 +319,25 @@ impl PyEmbeddings {
                 .write_embeddings(&mut writer)
                 .map_err(|err| exceptions::IOError::py_err(err.to_string())),
         }
+    }
+}
+
+impl PyEmbeddings {
+    fn similarity_results(
+        py: Python,
+        results: Vec<WordSimilarityResult>,
+    ) -> PyResult<Vec<PyObject>> {
+        let mut r = Vec::with_capacity(results.len());
+        for ws in results {
+            r.push(
+                Py::new(
+                    py,
+                    PyWordSimilarity::new(ws.word.to_owned(), ws.similarity.into_inner()),
+                )?
+                .into_object(py),
+            )
+        }
+        Ok(r)
     }
 }
 
@@ -371,4 +408,48 @@ where
     Ok(PyEmbeddings {
         embeddings: Rc::new(RefCell::new(EmbeddingsWrap::View(embeddings.into()))),
     })
+}
+
+struct Skips<'a>(HashSet<&'a str>);
+
+impl<'a> FromPyObject<'a> for Skips<'a> {
+    fn extract(ob: &'a PyAny) -> Result<Self, PyErr> {
+        let mut set = ob
+            .len()
+            .map(|len| HashSet::with_capacity(len))
+            .unwrap_or_default();
+
+        let iter = if <PySet as PyTypeInfo>::is_instance(ob) {
+            ob.iter().unwrap()
+        } else if <PyList as PyTypeInfo>::is_instance(ob) {
+            ob.iter().unwrap()
+        } else {
+            return Err(exceptions::TypeError::py_err("Iterable expected"));
+        };
+
+        for el in iter {
+            set.insert(
+                el?.extract()
+                    .map_err(|_| exceptions::TypeError::py_err("Expected String"))?,
+            );
+        }
+        Ok(Skips(set))
+    }
+}
+
+struct PyEmbedding<'a>(&'a PyArray1<f32>);
+
+impl<'a> FromPyObject<'a> for PyEmbedding<'a> {
+    fn extract(ob: &'a PyAny) -> Result<Self, PyErr> {
+        let embedding = ob
+            .downcast_ref::<PyArray1<f32>>()
+            .map_err(|_| exceptions::TypeError::py_err("Expected array with dtype Float32"))?;
+        if embedding.data_type() != NpyDataType::Float32 {
+            return Err(exceptions::TypeError::py_err(format!(
+                "Expected dtype Float32, got {:?}",
+                embedding.data_type()
+            )));
+        };
+        Ok(PyEmbedding(embedding))
+    }
 }

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,3 +1,6 @@
+import pytest
+import numpy
+
 SIMILARITY_ORDER_STUTTGART_10 = [
     "Karlsruhe",
     "Mannheim",
@@ -57,10 +60,28 @@ SIMILARITY_ORDER = [
 
 
 def test_similarity_berlin_40(similarity_fifu):
-    for idx, sim in enumerate(similarity_fifu.similarity("Berlin", 40)):
+    for idx, sim in enumerate(similarity_fifu.word_similarity("Berlin", 40)):
         assert SIMILARITY_ORDER[idx] == sim.word
 
 
 def test_similarity_stuttgart_10(similarity_fifu):
-    for idx, sim in enumerate(similarity_fifu.similarity("Stuttgart", 10)):
+    for idx, sim in enumerate(similarity_fifu.word_similarity("Stuttgart", 10)):
         assert SIMILARITY_ORDER_STUTTGART_10[idx] == sim.word
+
+
+def test_embedding_similarity_stuttgart_10(similarity_fifu):
+    stuttgart = similarity_fifu.embedding("Stuttgart")
+    sims = similarity_fifu.embedding_similarity(stuttgart, limit=10)
+    assert sims[0].word == "Stuttgart"
+
+    for idx, sim in enumerate(sims[1:]):
+        assert SIMILARITY_ORDER_STUTTGART_10[idx] == sim.word
+
+    for idx, sim in enumerate(similarity_fifu.embedding_similarity(stuttgart, skip={"Stuttgart"}, limit=10)):
+        assert SIMILARITY_ORDER_STUTTGART_10[idx] == sim.word
+
+
+def test_embedding_similarity_incompatible_shapes(similarity_fifu):
+    incompatible_embed = numpy.ones(1, dtype=numpy.float32)
+    with pytest.raises(ValueError):
+        similarity_fifu.embedding_similarity(incompatible_embed)


### PR DESCRIPTION
Add a method to perform similarity queries based on an input embedding rather than words.

________

The argument for the words to skip had to be wrapped in two `Option`s, otherwise the proc macro paniced, the behaviour in Python is the desired one anyways.

I factored out a method to return the results for `analogy`, `word_similarity` and `embedding_similarity` since the code was identical for all of them.
