### PR TITLE
Mark trait objects with dyn

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -40,7 +40,7 @@ impl PyEmbeddings {
     /// This should only be used for storage types that do not provide
     /// an ndarray view that can be copied trivially, such as quantized
     /// storage.
-    fn copy_storage_to_array(storage: &Storage) -> Array2<f32> {
+    fn copy_storage_to_array(storage: &dyn Storage) -> Array2<f32> {
         let (rows, dims) = storage.shape();
 
         let mut array = Array2::<f32>::zeros((rows, dims));

--- a/src/embeddings_wrap.rs
+++ b/src/embeddings_wrap.rs
@@ -8,7 +8,7 @@ pub enum EmbeddingsWrap {
 }
 
 impl EmbeddingsWrap {
-    pub fn storage(&self) -> &Storage {
+    pub fn storage(&self) -> &dyn Storage {
         use EmbeddingsWrap::*;
         match self {
             NonView(e) => e.storage(),


### PR DESCRIPTION
Rust 1.37.0 gives warnings for bare trait objects.