### PR TITLE
Implement __contains__ for vocab.

### DIFF
--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -75,4 +75,16 @@ impl PySequenceProtocol for PyVocab {
             Ok(words[idx as usize].clone())
         }
     }
+
+    fn __contains__(&self, word: String) -> PyResult<bool> {
+        let embeds = self.embeddings.borrow();
+        Ok(embeds
+            .vocab()
+            .idx(&word)
+            .map(|word_idx| match word_idx {
+                WordIndex::Word(_) => true,
+                WordIndex::Subword(_) => false,
+            })
+            .unwrap_or(false))
+    }
 }


### PR DESCRIPTION
Python performs linear search over sequences if `__contains__` is
not explicitly implemented. This is painfully slow over large
vocabularies, therefore implement `__contains__` explicitly.

Fixes #74 

thanks @twuebi and @ketxd for pointing this out.