### PR TITLE
Expose vocab_len as full_len.

### DIFF
--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -62,6 +62,12 @@ impl PyVocab {
             )),
         }
     }
+
+    /// Get the total length of this vocabulary, including possible subwords.
+    fn full_len(&self) -> usize {
+        let embeds = self.embeddings.borrow();
+        embeds.vocab().vocab_len()
+    }
 }
 
 #[pyproto]


### PR DESCRIPTION
Rather trivial change, expose the length including subwords. So far it's necessary to clone the embedding matrix just to get the maximum value that the vocab indexes.