### PR TITLE
Fix PyStorage doc.

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 
 use crate::EmbeddingsWrap;
 
-/// finalfusion vocab.
+/// finalfusion storage.
 #[pyclass(name=Storage)]
 pub struct PyStorage {
     embeddings: Rc<RefCell<EmbeddingsWrap>>,


### PR DESCRIPTION
`PyStorage` is the finalfusion storage, not vocabulary.