### PR TITLE
Add numpy as an installation dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ finalfusion = "0.11"
 ndarray = "0.13"
 numpy = "0.7"
 toml = "0.5"
+
+[package.metadata.maturin]
+requires-dist = ["numpy"]


### PR DESCRIPTION
Seems that maturin now supports this. Fixes #85.