### PR TITLE
Add default.nix to build in-place with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{
+  pkgs ? import <nixpkgs> {}
+, python ? pkgs.python3
+}:
+
+with python.pkgs;
+
+buildPythonPackage {
+  pname = "finalfusion";
+  version = "0.7.0-git";
+
+  src = pkgs.nix-gitignore.gitignoreSource [ ".git/" "*.nix" "result*" ] ./.;
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    toml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+   checkPhase = ''
+    pytest
+
+    patchShebangs tests/conversion_integration.sh
+    export PATH=$PATH:$out/bin
+    tests/conversion_integration.sh
+  '';
+}


### PR DESCRIPTION
To scratch my own itch.

Build/test with:

```
nix-build
```

Set up an environment with all dependencies:

```
nix-shell
```

Set up an environment where the module is in the Python path:

```
nix-shell -p 'import ./. {}'
```

We can use or derive a saner version once we have versions ;).