### PR TITLE
Implement analogy and similarity scripts.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
 [TYPECHECK]
 extension-pkg-whitelist=finalfusion.subword.hash_indexers, finalfusion.subword.explicit_indexer
+
+[SIMILARITY]
+ignore-imports=yes

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,8 @@ setup(name='finalfusion',
       entry_points=dict(console_scripts=[
           'ffp-convert=finalfusion.scripts.convert:main',
           'ffp-bucket-to-explicit=finalfusion.scripts.bucket_to_explicit:main',
+          'ffp-similar=finalfusion.scripts.similar:main',
+          'ffp-analogy=finalfusion.scripts.analogy:main',
       ]),
       version="0.7.0-pre"
       )

--- a/src/finalfusion/scripts/analogy.py
+++ b/src/finalfusion/scripts/analogy.py
@@ -1,0 +1,81 @@
+"""
+Analogy queries for embeddings.
+"""
+import argparse
+import sys
+from typing import List, Set
+
+from finalfusion.scripts.util import Format
+
+
+def main() -> None:  # pylint: disable=missing-function-docstring
+    formats = ["word2vec", "finalfusion", "fasttext", "text", "textdims"]
+    parser = argparse.ArgumentParser(prog="ffp-analogy",
+                                     description="Analogy queries.")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=formats,
+        type=str,
+        default="finalfusion",
+        help=f"Valid choices: {formats} Default: 'finalfusion'",
+        metavar="INPUT_FORMAT")
+    parser.add_argument("embeddings",
+                        help="Input embeddings",
+                        type=str,
+                        metavar="EMBEDDINGS")
+    parser.add_argument(
+        "-i",
+        "--include",
+        choices=["a", "b", "c"],
+        nargs="+",
+        default=[],
+        help=
+        "Specify query parts that should be allowed as answers. Valid choices: ['a', 'b', 'c']"
+    )
+    parser.add_argument("-k",
+                        type=int,
+                        default=10,
+                        help=f"Number of neighbours. Default: 1",
+                        metavar="K")
+    parser.add_argument("input", nargs='?', default=0)
+    args = parser.parse_args()
+    if args.include != [] and len(args.include) > 3:
+        print("-i/--include can take up to 3 unique values: a, b and c.",
+              file=sys.stderr)
+        sys.exit(1)
+    embeds = Format(args.format).load(args.embeddings)
+    with open(args.input) as queries:
+        for query in queries:
+            query_a, query_b, query_c = query.strip().split()
+            skips = get_skips(query_a, query_b, query_c, args.include)
+            res = embeds.analogy(query_a,
+                                 query_b,
+                                 query_c,
+                                 k=args.k,
+                                 skip=skips)
+            if res is None:
+                print(
+                    f"Could not compute for: {query_a} : {query_b}, {query_c} : ? ",
+                    file=sys.stderr)
+            else:
+                print("\n".join(f"{ws.word} {ws.similarity}" for ws in res))
+
+
+def get_skips(  # pylint: disable=missing-function-docstring
+        query_a: str, query_b: str, query_c: str,
+        includes: List[str]) -> Set[str]:
+    if includes == []:
+        return {query_c, query_b, query_a}
+    skips = set()
+    if 'a' not in includes:
+        skips.add(query_a)
+    if 'b' not in includes:
+        skips.add(query_b)
+    if 'c' not in includes:
+        skips.add(query_b)
+    return skips
+
+
+if __name__ == '__main__':
+    main()

--- a/src/finalfusion/scripts/similar.py
+++ b/src/finalfusion/scripts/similar.py
@@ -1,0 +1,48 @@
+"""
+Similarity queries for embeddings.
+"""
+import argparse
+import sys
+
+from finalfusion.scripts.util import Format
+
+
+def main() -> None:  # pylint: disable=missing-function-docstring
+    formats = ["word2vec", "finalfusion", "fasttext", "text", "textdims"]
+    parser = argparse.ArgumentParser(prog="ffp-similar",
+                                     description="Similarity queries.")
+    parser.add_argument("embeddings",
+                        type=str,
+                        help="Input embeddings",
+                        metavar="EMBEDDINGS")
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        choices=formats,
+        default="finalfusion",
+        help=f"Valid choices: {formats} Default: 'finalfusion'",
+        metavar="INPUT_FORMAT")
+    parser.add_argument("-k",
+                        type=int,
+                        default=10,
+                        help=f"Number of neighbours. Default: 10",
+                        metavar="K")
+    parser.add_argument("input", nargs='?', default=0)
+    args = parser.parse_args()
+    embeds = Format(args.format).load(args.embeddings)
+    with open(args.input) as queries:
+        for query in queries:
+            query = query.strip()
+            if not query:
+                continue
+            res = embeds.word_similarity(query, k=args.k)
+            if res is None:
+                print(f"Could not compute neighbours for: {query}",
+                      file=sys.stderr)
+            else:
+                print("\n".join(f"{ws.word} {ws.similarity}" for ws in res))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/all.sh
+++ b/tests/integration/all.sh
@@ -3,8 +3,19 @@ set -eu
 
 TESTDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
+if [ -v OS ] && [ "${OS}" = Windows_NT ]; then
+    export PYTHONIOENCODING=utf-8
+    export PYTHONUTF8=1
+fi
+
 echo conversions >&2
 "${TESTDIR}"/conversion.sh
 
 echo bucket-to-explicit >&2
 "${TESTDIR}"/bucket_to_explicit.sh
+
+echo similarity >&2
+"${TESTDIR}"/similarity.sh
+
+echo analogy >&2
+"${TESTDIR}"/analogy.sh

--- a/tests/integration/analogy.sh
+++ b/tests/integration/analogy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -eu
+export LC_ALL=en_US.UTF-8
+
+tmp_dir=$(mktemp -d /tmp/run_similarity.XXXXXX)
+
+function finish() {
+  rm -rf "$tmp_dir"
+}
+
+trap finish EXIT
+
+TESTDIR="$(
+  cd "$(dirname "$0")" >/dev/null 2>&1
+  pwd -P
+)"
+
+EXPECTED="Deutschland
+Westdeutschland
+Sachsen
+Mitteldeutschland
+Brandenburg
+Polen
+Norddeutschland
+Dänemark
+Schleswig-Holstein
+Österreich
+Bayern
+Thüringen
+Bundesrepublik
+Ostdeutschland
+Preußen
+Deutschen
+Hessen
+Potsdam
+Mecklenburg
+Niedersachsen
+Hamburg
+Süddeutschland
+Bremen
+Russland
+Deutschlands
+BRD
+Litauen
+Mecklenburg-Vorpommern
+DDR
+West-Berlin
+Saarland
+Lettland
+Hannover
+Rostock
+Sachsen-Anhalt
+Pommern
+Schweden
+Deutsche
+deutschen
+Westfalen"
+
+diff <(echo Paris Frankreich Berlin | \
+      ffp-analogy "${TESTDIR}/../data/simple_vocab.fifu" -k 40 | \
+      cut -f 1 -d " ") \
+      <(echo "${EXPECTED}")
+
+diff <(echo Paris Frankreich Paris | \
+      ffp-analogy "${TESTDIR}/../data/simple_vocab.fifu" -k 1 -i a b c | \
+       cut -f 1 -d " ") \
+     <(echo "Frankreich")
+
+diff <(echo Paris Frankreich Paris | \
+       ffp-analogy "${TESTDIR}/../data/simple_vocab.fifu" -k 1 -i a c | \
+       cut -f 1 -d " ") \
+     <(echo "Russland")
+
+diff <(echo Frankreich Frankreich Frankreich | \
+      ffp-analogy "${TESTDIR}/../data/simple_vocab.fifu" -k 1 -i a b c | \
+      cut -f 1 -d " ") \
+     <(echo "Frankreich")
+
+diff <(echo Frankreich Frankreich Frankreich | \
+      ffp-analogy "${TESTDIR}/../data/simple_vocab.fifu" -k 1 | \
+      cut -f 1 -d " ") \
+     <(echo "Russland")

--- a/tests/integration/similarity.sh
+++ b/tests/integration/similarity.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -eu
+tmp_dir=$(mktemp -d /tmp/run_similarity.XXXXXX)
+
+function finish() {
+  rm -rf "$tmp_dir"
+}
+
+trap finish EXIT
+
+TESTDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+EXPECTED="Karlsruhe
+Mannheim
+München
+Darmstadt
+Heidelberg
+Wiesbaden
+Kassel
+Düsseldorf
+Leipzig
+Berlin"
+
+diff <(echo Stuttgart | ffp-similar "tests/data/similarity.fifu" | cut -f 1 -d " ") <(echo "${EXPECTED}")
+
+EXPECTED="Potsdam
+Hamburg
+Leipzig
+Dresden
+München
+Düsseldorf
+Bonn
+Stuttgart
+Weimar
+Berlin-Charlottenburg
+Rostock
+Karlsruhe
+Chemnitz
+Breslau
+Wiesbaden
+Hannover
+Mannheim
+Kassel
+Köln
+Danzig
+Erfurt
+Dessau
+Bremen
+Charlottenburg
+Magdeburg
+Neuruppin
+Darmstadt
+Jena
+Wien
+Heidelberg
+Dortmund
+Stettin
+Schwerin
+Neubrandenburg
+Greifswald
+Göttingen
+Braunschweig
+Berliner
+Warschau
+Berlin-Spandau"
+diff <(echo Berlin | ffp-similar "tests/data/similarity.fifu" -k 40 | cut -f 1 -d " ") <(echo "${EXPECTED}")


### PR DESCRIPTION
Tests were awful to set up on this one. Github uses Git for Windows' bash emulator for Windows CI which sets the default encoding to UTF8 which apparently doesn't change the default encoding for Python.

So Python prints in native Windows encoding while the target strings defined in the bash script end up being encoded in UTF8. Quite frustrating.