### PR TITLE
Fix release workflow.

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -42,7 +42,7 @@ jobs:
         pip install dist/*.whl pytest
         pytest
     - name: Test mac wheel system python
-      if: {{ matrix.python.version == '3.7' }}
+      if: ${{ matrix.python-version == '3.7' }}
       run: |
         /usr/bin/python3 -m venv venv
         source venv/bin/activate
@@ -70,10 +70,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel==0.31.1 twine cython
         python setup.py bdist_wheel
-    - name: Test windows wheel
-      run: |
-        pip install dist/*.whl pytest
-        pytest
     - name: Publish windows
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
Can't get installing and testing the wheel to work on CI. It works locally on my windows system with all 3 python versions.