### PR TITLE
Fix building wheels for manylinux1.

### DIFF
--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -2,14 +2,15 @@
 set -ex
 
 cd io
-
+export MANYLINUX=1
 for PYBIN in /opt/python/cp{36,37,38}*/bin; do
-    export PYTHON_SYS_EXECUTABLE="$PYBIN/python"
     "${PYBIN}/pip" install cython setuptools wheel
     "${PYBIN}/python" setup.py bdist_wheel
+    rm -f src/finalfusion/subword/*.c
     if [[ $PYBIN == "/opt/python/cp36-cp36m/bin" ]]
       then
         "${PYBIN}/python" setup.py sdist
+        rm -f src/finalfusion/subword/*.c
     fi
 done
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ need_cython = not all(map(os.path.exists, c_paths))
 annotate = "--annotate" in sys.argv
 force = "--force" in sys.argv or annotate
 
+if os.environ.get('MANYLINUX'):
+    extra_compile_args = ['-DFOR_MANYLINUX']
+else:
+    extra_compile_args = []
+
 if need_cython or force or annotate:
     try:
         from Cython.Build import cythonize
@@ -54,19 +59,20 @@ if need_cython or force or annotate:
     hash_indexers = Extension(
         "finalfusion.subword.hash_indexers",
         ["src/finalfusion/subword/hash_indexers.pyx", "src/fnv/hash_64a.c"],
-        include_dirs=["src/fnv/", "src/include"])
+        include_dirs=["src/fnv/", "src/include"], extra_compile_args=extra_compile_args)
     ngrams = Extension("finalfusion.subword.ngrams",
                        ["src/finalfusion/subword/ngrams.pyx"])
     explicit_indexer = Extension(
         "finalfusion.subword.explicit_indexer",
         ["src/finalfusion/subword/explicit_indexer.pyx"])
-    extensions = cythonize([hash_indexers, ngrams, explicit_indexer], force=force)
+    extensions = cythonize([hash_indexers, ngrams, explicit_indexer],
+                           force=force)
 else:
     # sdist should include the C files so Cython isn't required
     hash_indexers = Extension(
         "finalfusion.subword.hash_indexers",
         ["src/finalfusion/subword/hash_indexers.c", "src/fnv/hash_64a.c"],
-        include_dirs=["src/fnv/", "src/include"])
+        include_dirs=["src/fnv/", "src/include"], extra_compile_args=extra_compile_args)
     ngrams = Extension("finalfusion.subword.ngrams",
                        ["src/finalfusion/subword/ngrams.c"])
     explicit_indexer = Extension(

--- a/src/include/portable_endian.h
+++ b/src/include/portable_endian.h
@@ -22,9 +22,26 @@
 
 #	include <endian.h>
 
-#elif defined(__linux__) || defined(__CYGWIN__)
+#elif defined(__linux__) && !defined(FOR_MANYLINUX) || defined(__CYGWIN__)
 
 #	include <endian.h>
+
+#elif defined(FOR_MANYLINUX)
+
+#   define htobe16(x) __builtin_bswap16(x)
+#   define htole16(x) (x)
+#   define be16toh(x) __builtin_bswap16(x)
+#   define le16toh(x) (x)
+
+#   define htobe32(x) __builtin_bswap32(x)
+#   define htole32(x) (x)
+#   define be32toh(x) __builtin_bswap32(x)
+#   define le32toh(x) (x)
+
+#   define htobe64(x) __builtin_bswap64(x)
+#   define htole64(x) (x)
+#   define be64toh(x) __builtin_bswap64(x)
+#   define le64toh(x) (x)
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
Published wheels for manylinux are broken because centos 5 doesn't include the endian conversion methods assumed by `portable_endian.h`.

This fixes the problems by defining a macro depending the `MANYLINUX` environment flag.

It doesn't feel like a clean fix but it works for all architectures in CI and for me locally with the manylinux1 docker.