### PR TITLE
Nix buildPythonPkg with pyproject.toml

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ with python.pkgs;
 buildPythonPackage {
   pname = "finalfusion";
   version = "0.7.0-git";
+  format = "pyproject";
 
   src = pkgs.nix-gitignore.gitignoreSource [ ".git/" "*.nix" "result*" ] ./.;
 


### PR DESCRIPTION
`nix-shell -p 'import ./. {}'`

Builds the package, runs tests and drops me into a shell where I can import & use the package. Found at https://nixos.org/nixpkgs/manual/#python 15.17.2.2.1.1