### PR TITLE
Nix: override shellHook to run pip without build isolation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,11 +24,25 @@ buildPythonPackage {
     pytest
   ];
 
-   checkPhase = ''
+  checkPhase = ''
     pytest
 
     patchShebangs tests/integration
     export PATH=$PATH:$out/bin
     tests/integration/all.sh
+  '';
+
+  # Remove when nixpkgs#89607 is merged/fixed.
+  shellHook = ''
+    runHook preShellHook
+
+    tmp_path=$(mktemp -d)
+    export PATH="$tmp_path/bin:$PATH"
+    export PYTHONPATH="$tmp_path/${python.sitePackages}:$PYTHONPATH"
+    mkdir -p "$tmp_path/${python.sitePackages}"
+    ${python.pythonForBuild.interpreter} -m pip install -e . \
+      --prefix "$tmp_path" --no-build-isolation >&2
+
+    runHook postShellHook
   '';
 }


### PR DESCRIPTION
Band-aid until the shell hook in nixpkgs is fixed.