### PR TITLE
Add shell.nix that uses a virtual environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,26 @@
+{
+  pkgs ? import <nixpkgs> {}
+, python ? pkgs.python3
+}:
+
+with pkgs;
+
+mkShell rec {
+  venvDir = "./.venv";
+
+  buildInputs = with python3.pkgs; [
+    cython
+    numpy
+    pytest
+    toml
+    venvShellHook
+  ];
+
+  postShellHook = ''
+    # Ensure use of the venv Python interpreter.
+    alias pytest="${venvDir}/bin/python -m pytest"
+   
+    # Install ourselves in the venv. 
+    pip install -e .
+  '';
+}


### PR DESCRIPTION
**Warning:** not sure if I like this.

After running nix-shell, you can use pip as usual, e.g.:

pip install -e .

And it will install packages into the virtual environment under
`.venv`.

Warning: this switches back to impure package handling in the form of
a virtual environment. For pure builds, it's better to use
`nix-build`, for pure handling of dependencies use `nix-shell
default.nix`.