### PR TITLE
Make repr implementations more informative.

### DIFF
--- a/src/finalfusion/compat/fasttext.py
+++ b/src/finalfusion/compat/fasttext.py
@@ -54,7 +54,8 @@ def load_fasttext(file: Union[str, bytes, int, PathLike],
     return Embeddings(storage=storage,
                       vocab=vocab,
                       norms=norms,
-                      metadata=metadata)
+                      metadata=metadata,
+                      origin=inf.name)
 
 
 def write_fasttext(file: Union[str, bytes, int, PathLike], embeds: Embeddings):

--- a/src/finalfusion/compat/text.py
+++ b/src/finalfusion/compat/text.py
@@ -150,7 +150,8 @@ def _load_text(file: TextIO, rows: int, cols: int) -> Embeddings:
     storage = NdArray(matrix)
     return Embeddings(storage=storage,
                       norms=_normalize_matrix(storage),
-                      vocab=SimpleVocab(words))
+                      vocab=SimpleVocab(words),
+                      origin=file.name)
 
 
 def _write_text(file: Union[str, bytes, int, PathLike],

--- a/src/finalfusion/compat/word2vec.py
+++ b/src/finalfusion/compat/word2vec.py
@@ -53,7 +53,8 @@ def load_word2vec(file: Union[str, bytes, int, PathLike],
     storage = NdArray(matrix)
     return Embeddings(storage=storage,
                       norms=_normalize_matrix(storage),
-                      vocab=SimpleVocab(words))
+                      vocab=SimpleVocab(words),
+                      origin=inf.name)
 
 
 def write_word2vec(file: Union[str, bytes, int, PathLike],

--- a/src/finalfusion/subword/explicit_indexer.pyx
+++ b/src/finalfusion/subword/explicit_indexer.pyx
@@ -203,10 +203,9 @@ cdef class ExplicitIndexer:
         return False
 
     def __repr__(self) -> str:
-        return "ExplicitIndexer(\n" \
-               f"\tmin_n={self.min_n},\n" \
-               f"\tmax_n={self.max_n},\n" \
-               "\tngrams=[...],\n" \
-               "\tngram_index={{...}})"
+        return f"ExplicitIndexer(min_n={self.min_n}, " \
+               f"max_n={self.max_n}, " \
+               f"n_ngrams={len(self.ngrams)}, " \
+               f"n_indices={self.upper_bound})"
 
 __all__ = ['ExplicitIndexer']

--- a/src/finalfusion/vocab/subword.py
+++ b/src/finalfusion/vocab/subword.py
@@ -131,9 +131,10 @@ class SubwordVocab(Vocab):
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(\n" \
+               f"\tn_words={len(self)},\n" \
+               f"\tupper_bound={self.upper_bound},\n" \
                f"\tindexer={self.subword_indexer}\n" \
-               "\twords=[...]\n" \
-               "\tword_index={{...}})"
+                ")"
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, type(self)) and \

--- a/src/finalfusion/vocab/vocab.py
+++ b/src/finalfusion/vocab/vocab.py
@@ -98,6 +98,9 @@ class Vocab(Chunk, Collection[str]):
             return False
         return True
 
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(n_words={len(self)}, upper_bound={self.upper_bound})"
+
 
 def _write_words_binary(b_words: Iterable[bytes], file: BinaryIO):
     """

--- a/tests/test_subwords.py
+++ b/tests/test_subwords.py
@@ -77,11 +77,8 @@ def test_explicit():
     indexer = ExplicitIndexer(ngrams10)
     assert indexer.ngrams == ngrams10
     assert indexer.ngram_index == dict((v, i) for i, v in enumerate(ngrams10))
-    assert repr(indexer) == "ExplicitIndexer(\n" \
-                               "\tmin_n=3,\n" \
-                               "\tmax_n=6,\n" \
-                               "\tngrams=[...],\n" \
-                               "\tngram_index={{...}})"
+    assert repr(indexer) == "ExplicitIndexer(min_n=3, max_n=6, " \
+                            "n_ngrams=10, n_indices=10)"
     assert indexer["0"] == 0
     assert indexer.ngrams[0] == "0"
     assert indexer("0") == 0

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -83,10 +83,11 @@ def test_fifu_buckets_constructor():
     assert v in v
     assert v != SimpleVocab(v.words)
     assert v != FinalfusionBucketVocab(v.words, FinalfusionHashIndexer(20))
-    assert repr(v) == f"FinalfusionBucketVocab(\n" \
+    assert repr(v) == "FinalfusionBucketVocab(\n" \
+                      f"\tn_words={len(v)},\n" \
+                      f"\tupper_bound={len(v) + pow(2, 21)},\n" \
                       f"\tindexer={repr(v.subword_indexer)}\n" \
-                      "\twords=[...]\n" \
-                      "\tword_index={{...}})"
+                      f")"
 
 
 def test_fasttext_constructor():
@@ -102,10 +103,11 @@ def test_fasttext_constructor():
     assert v in v
     assert v != SimpleVocab(v.words)
     assert v != FastTextVocab(v.words, FastTextIndexer(20))
-    assert repr(v) == f"FastTextVocab(\n" \
+    assert repr(v) == "FastTextVocab(\n" \
+                      f"\tn_words={len(v)},\n" \
+                      f"\tupper_bound={len(v) + 2_000_000},\n" \
                       f"\tindexer={repr(v.subword_indexer)}\n" \
-                      "\twords=[...]\n" \
-                      "\tword_index={{...}})"
+                      f")"
 
 
 def test_fasttext_vocab_roundtrip(tmp_path):
@@ -128,10 +130,11 @@ def test_explicit_constructor():
     assert v in v
     assert v != SimpleVocab(v.words)
     assert v != FastTextVocab(v.words, FastTextIndexer(20))
-    assert repr(v) == f"ExplicitVocab(\n" \
+    assert repr(v) == "ExplicitVocab(\n" \
+                      f"\tn_words={len(v)},\n" \
+                      f"\tupper_bound={len(v) + 10},\n" \
                       f"\tindexer={repr(v.subword_indexer)}\n" \
-                      "\twords=[...]\n" \
-                      "\tword_index={{...}})"
+                      f")"
 
 
 def test_explicit_vocab_roundtrip(tmp_path):


### PR DESCRIPTION
Add origin string for Embeddings and make reprs for vocabulary
types and the explicit indexer more informative.

---------

I want to add a `mmap` property to storage & embeddings in a followup and also include that in the embeddings repr.