### PR TITLE
Restrict fastText writing and config values.

### DIFF
--- a/tests/integration/conversion.sh
+++ b/tests/integration/conversion.sh
@@ -23,7 +23,6 @@ function verify_all_conversions() {
   local out_path_prefix=${tmp_dir}/${in_format}
   convert_and_verify "${input}" "${in_format}" "${out_path_prefix}_to_fifu.fifu" finalfusion
   convert_and_verify "${input}" "${in_format}" "${out_path_prefix}_to_w2v.w2v" word2vec
-  convert_and_verify "${input}" "${in_format}" "${out_path_prefix}_to_ft.bin" fasttext
   convert_and_verify "${input}" "${in_format}" "${out_path_prefix}_to_text.txt" text
   convert_and_verify "${input}" "${in_format}" "${out_path_prefix}_to_text.dims.txt" textdims
 }
@@ -58,3 +57,6 @@ convert_and_verify "${input}" finalfusion \
 
 input="${TESTDIR}/../data/fasttext.bin"
 verify_all_conversions  "${input}" fasttext
+convert_and_verify "${input}" fasttext "${tmp_dir}/fasttext_to_ft.bin" fasttext
+
+

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -69,14 +69,3 @@ def test_fasttext_roundtrip(embeddings_ft, tmp_path):
     assert np.allclose(embeddings_ft.norms, ft.norms)
     for a, b in zip(embeddings_ft.storage, ft.storage):
         assert np.allclose(a, b, atol=1e-5)
-    assert embeddings_ft.metadata == ft.metadata
-
-
-def test_text_to_ft(embeddings_text, tmp_path):
-    filename = tmp_path / "txt-to-ft.bin"
-    write_fasttext(filename, embeddings_text)
-    ft = load_fasttext(filename)
-    assert embeddings_text.vocab == ft.vocab
-    assert np.allclose(embeddings_text.norms, ft.norms)
-    for a, b in zip(embeddings_text.storage, ft.storage):
-        assert np.allclose(a, b, atol=1e-5)


### PR DESCRIPTION
Remove ability to serialize SimpleVocab embeddings to fastText,
restrict fastText config values to those that can be inferred from
the model. Other values are represented by dummy values.

---------

Syncs fastText writing with `finalfusion-rust`